### PR TITLE
Add data collection and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The events are:
  * `[timestamp, 'task-created', taskId]`
  * `[timestamp, 'task-started', taskId, workerId]`
  * `[timestamp, 'task-resolved', taskId]`
- * `[timestamp, 'worker-requested', workerId]`
+ * `[timestamp, 'worker-requested', workerId, {capacity, utility}]`
  * `[timestamp, 'worker-started', workerId]`
  * `[timestamp, 'worker-shutdown', workerId]`
 

--- a/main.js
+++ b/main.js
@@ -1,11 +1,13 @@
 const chalk = require('chalk');
 const {program} = require('commander');
 const {version} = require('./package.json');
+const fs = require('fs');
 
 program.version(version);
 
 program
   .option('-q, --quiet', 'silence logging')
+  .option('-o, --output <output>', 'datastore ouptut')
   .arguments('<simulation>')
   .action((simName, options) => {
     const Simulator = require(`./sims/${simName}`);
@@ -14,6 +16,10 @@ program
     });
 
     sim.run();
+    if (options.output) {
+      const ds = sim.dataStore();
+      fs.writeFileSync(options.output, JSON.stringify(ds.asSerializable()));
+    }
   });
 
 program.parse();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "slugid": "^2.0.0"
   },
   "devDependencies": {
-    "mocha": "^8.1.0"
+    "mocha": "^8.1.0",
+    "mock-fs": "^4.12.0"
   }
 }

--- a/sims/loadgen/ticktock.js
+++ b/sims/loadgen/ticktock.js
@@ -6,7 +6,9 @@ class TickTockLoadGenerator extends LoadGenerator {
     super({core, queue});
     this.taskEvery = taskEvery;
     this.taskDuration = taskDuration;
+  }
 
+  start() {
     // start a task every second
     this.runIntervalId = this.core.setInterval(() => this.startTask(), this.taskEvery);
   }

--- a/sims/prov/simple.js
+++ b/sims/prov/simple.js
@@ -21,7 +21,9 @@ class SimpleEstimateProvisioner extends Provisioner {
 
     this.requestedWorkers = new Map();
     this.runningWorkers = new Map();
+  }
 
+  start() {
     this.core.setInterval(() => this.loop(), 1000);
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -8,7 +8,7 @@ class Core {
       this.log = () => {};
     }
 
-    this._now = new Date(2020, 0, 0).getTime();
+    this._now = 0;
     this.queue = new PriorityQueue((a, b) => (b[0] > a[0] ? 1 : b[0] < a[0] ? -1 : 0));
   }
 

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -89,6 +89,8 @@ class DataStore {
     const resolvedTasks = new Map();
 
     // workerId -> {
+    //   capacity,
+    //   utility,
     //   requestedTime,
     //   startedTime,
     //   shutdownTime,
@@ -144,8 +146,10 @@ class DataStore {
         }
 
         case 'worker-requested': {
-          const [workerId] = rest;
+          const [workerId, {capacity, utility}] = rest;
           requestedWorkers.set(workerId, {
+            capacity,
+            utility,
             requestedTime: time,
             runningTasks: new Map(),
             resolvedTasks: new Map(),

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -1,0 +1,78 @@
+/**
+ * A data store records the main part of a simulation run as a sequence of
+ * events, including events from the ramp-up and ramp-down periods as context.
+ * These events are available in `ds.events`.
+ *
+ * The events are
+ *   [timestamp, 'task-created', taskId]
+ *   [timestamp, 'task-started', taskId, workerId]
+ *   [timestamp, 'task-resolved', taskId]
+ *   [timestamp, 'worker-requested', workerId]
+ *   [timestamp, 'worker-started', workerId]
+ *   [timestamp, 'worker-shutdown', workerId]
+ *
+ * The simulation always begins at time 0, and its duration is given by
+ * `ds.duration`.  The events from the ramp-up period will have negative
+ * timestamps, and events from the ramp-down period will have timestamps
+ * greater than `ds.duration`.
+ */
+class DataStore {
+  /**
+   * Construct a data store from a Recorder, applying normalizations
+   */
+  static fromRecorder({events, startTime, stopTime}) {
+    const ignoreWorkers = new Set();
+    const ignoreTasks = new Set();
+
+    for (let [time, name, id] of events) {
+      if (time < startTime) {
+        switch (name) {
+          case 'task-resolved':
+            ignoreTasks.add(id);
+            break;
+          case 'worker-shutdown':
+            ignoreWorkers.add(id);
+            break;
+        }
+      } else if (time > stopTime) {
+        switch (name) {
+          case 'task-created':
+            ignoreTasks.add(id);
+            break;
+          case 'worker-requested':
+            ignoreWorkers.add(id);
+            break;
+        }
+      }
+    }
+
+    const ds = new DataStore();
+    ds.duration = stopTime - startTime;
+    ds.events = events
+      .filter(([_, name, id]) =>
+        !((name.startsWith('task-') && ignoreTasks.has(id)) ||
+        (name.startsWith('worker-') && ignoreWorkers.has(id))))
+      .map(([t, ...rest]) => ([t - startTime, ...rest]));
+
+    return ds;
+  }
+
+  /**
+   * Convert to a JSON-serializable format
+   */
+  asSerializable() {
+    return {
+      duration: this.duration,
+      events: this.events,
+    };
+  }
+
+  /**
+   * Create from a JSON serializable format.
+   */
+  static fromSerializable(ser) {
+    return Object.assign(new DataStore(), ser);
+  }
+}
+
+module.exports = {DataStore};

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -73,6 +73,159 @@ class DataStore {
   static fromSerializable(ser) {
     return Object.assign(new DataStore(), ser);
   }
+
+  /**
+   * Calculate metrics with the given interval
+   */
+  calculateMetrics({interval, metrics, updateState, initialState}) {
+    const events = this.events;
+    const duration = this.duration;
+
+    // track the current state as we see events..
+
+    // taskId -> {createdTime, startedTime, resolvedTime, workerId}
+    const pendingTasks = new Map();
+    const runningTasks = new Map();
+    const resolvedTasks = new Map();
+
+    // workerId -> {
+    //   requestedTime,
+    //   startedTime,
+    //   shutdownTime,
+    //   runningTasks: taskId -> {createdTime, startedTime},
+    //   resolvedTasks: taskId -> {createdTime, startedTime, resolvedTime},
+    // }
+    const requestedWorkers = new Map();
+    const runningWorkers = new Map();
+    const shutdownWorkers = new Map();
+
+    const state = {
+      ...initialState,
+      pendingTasks, runningTasks, resolvedTasks,
+      requestedWorkers, runningWorkers, shutdownWorkers,
+    };
+
+    // move a value from one map to another and return it
+    const move = (key, map1, map2) => {
+      const val = map1.get(key);
+      map1.delete(key);
+      map2.set(key, val);
+      return val;
+    };
+
+    const updateBuiltInState = ([time, name, ...rest]) => {
+      switch (name) {
+        case 'task-created': {
+          const [taskId] = rest;
+          pendingTasks.set(taskId, {createdTime: time});
+          break;
+        }
+
+        case 'task-started': {
+          const [taskId, workerId] = rest;
+
+          const task = move(taskId, pendingTasks, runningTasks);
+          task.startedTime = time;
+          task.workerId = workerId;
+
+          const worker = runningWorkers.get(workerId);
+          worker.runningTasks.set(taskId, task);
+          break;
+        }
+
+        case 'task-resolved': {
+          const [taskId] = rest;
+          const task = move(taskId, runningTasks, resolvedTasks);
+          task.resolvedTime = time;
+
+          const worker = runningWorkers.get(task.workerId);
+          move(taskId, worker.runningTasks, worker.resolvedTasks);
+          break;
+        }
+
+        case 'worker-requested': {
+          const [workerId] = rest;
+          requestedWorkers.set(workerId, {
+            requestedTime: time,
+            runningTasks: new Map(),
+            resolvedTasks: new Map(),
+          });
+          break;
+        }
+
+        case 'worker-started': {
+          const [workerId] = rest;
+          const worker = move(workerId, requestedWorkers, runningWorkers);
+          worker.startedTime = time;
+          break;
+        }
+
+        case 'worker-shutdown': {
+          const [workerId] = rest;
+          const worker = move(workerId, runningWorkers, shutdownWorkers);
+          worker.shutdownTime = time;
+          break;
+        }
+      }
+    };
+
+    // ..and generate metrics based on that current state
+
+    const result = [];
+    const generateMetrics = time => {
+      const sample = {time};
+      for (let [m, fn] of Object.entries(metrics)) {
+        sample[m] = fn(state);
+      }
+      result.push(sample);
+    };
+
+    // now loop over events, sampling at the desired time intervals
+
+    let nextTime = 0;
+    let n = this.events.length;
+    for (let i = 0; i < n; i++) {
+      const event = events[i];
+      while (event[0] > nextTime) {
+        generateMetrics(nextTime);
+        nextTime += interval;
+        if (nextTime > duration) {
+          return result;
+        }
+      }
+      updateBuiltInState(event);
+      updateState && updateState(state, event);
+    }
+
+    return result;
+  }
+
+  /**
+   * Utility metrics for calculateMetrics
+   */
+  static pendingTasks(state) {
+    return state.pendingTasks.size;
+  }
+
+  static runningTasks(state) {
+    return state.runningTasks.size;
+  }
+
+  static resolvedTasks(state) {
+    return state.resolvedTasks.size;
+  }
+
+  static requestedWorkers(state) {
+    return state.requestedWorkers.size;
+  }
+
+  static runningWorkers(state) {
+    return state.runningWorkers.size;
+  }
+
+  static shutdownWorkers(state) {
+    return state.shutdownWorkers.size;
+  }
 }
 
 module.exports = {DataStore};

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@ module.exports = {
   ...require('./loadgen'),
   ...require('./provisioner'),
   ...require('./worker'),
+  ...require('./datastore'),
 };

--- a/src/loadgen.js
+++ b/src/loadgen.js
@@ -6,6 +6,7 @@ class LoadGenerator extends Component {
     this.queue = queue;
   }
 
+  start() {}
   stop() {}
 }
 

--- a/src/provisioner.js
+++ b/src/provisioner.js
@@ -5,7 +5,7 @@ const {Component} = require('./component');
  * Base class for Provisioners
  *
  * This emits:
- *   'requested', workerId -- when a worker is requested
+ *   'requested', workerId, {capacity, utility} -- when a worker is requested
  *   'started', workerId -- when a worker starts up and attempts its first claim
  *   'shutdown', workerId -- when a worker shuts down
   */
@@ -18,10 +18,10 @@ class Provisioner extends Component {
   }
 
   registerWorker(worker) {
-    const name = worker.name;
+    const {name, capacity, utility} = worker;
     this.workers.set(name, worker);
 
-    this.emit('requested', name);
+    this.emit('requested', name, {capacity, utility});
     worker.once('started', () => this.emit('started', name));
     worker.once('shutdown', () => {
       this.workers.delete(name);

--- a/src/provisioner.js
+++ b/src/provisioner.js
@@ -1,6 +1,14 @@
 const assert = require('assert');
 const {Component} = require('./component');
 
+/**
+ * Base class for Provisioners
+ *
+ * This emits:
+ *   'requested', workerId -- when a worker is requested
+ *   'started', workerId -- when a worker starts up and attempts its first claim
+ *   'shutdown', workerId -- when a worker shuts down
+  */
 class Provisioner extends Component {
   constructor({core}) {
     super({core});
@@ -12,10 +20,15 @@ class Provisioner extends Component {
   registerWorker(worker) {
     const name = worker.name;
     this.workers.set(name, worker);
+
+    this.emit('requested', name);
+    worker.once('started', () => this.emit('started', name));
     worker.once('shutdown', () => {
       this.workers.delete(name);
     });
   }
+
+  start() {}
 
   stop() {
     // check that all workers have stopped

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -1,0 +1,63 @@
+const { DataStore } = require('./datastore');
+
+/**
+ * A recorder records the progress of a simulation and can produce a
+ * DataStore at the end.
+ */
+class Recorder {
+  constructor(simulator) {
+    this.simulator = simulator;
+    this.core = simulator.core;
+
+    this.events = [];
+    this.startTime = null;
+    this.stopTime = null;
+
+    this.setup();
+  }
+
+  /**
+   * Set up to record all events for tasks and workers
+   */
+  setup() {
+    const evt = name => (...args) => {
+      this.events.push([this.core.now(), name, ...args]);
+    };
+
+    this.simulator.queue.on('created', evt('task-created'));
+    this.simulator.queue.on('started', evt('task-started'));
+    this.simulator.queue.on('resolved', evt('task-resolved'));
+
+    this.simulator.provisioner.on('requested', evt('worker-requested'));
+    this.simulator.provisioner.on('started', evt('worker-started'));
+    this.simulator.provisioner.on('shutdown', evt('worker-shutdown'));
+  }
+
+  /**
+   * Start the actual simulation (after the ramp-up period)
+   */
+  start() {
+    this.startTime = this.core.now();
+  }
+
+  /**
+   * Stop the simulation (and begin ramping down)
+   */
+  stop() {
+    this.stopTime = this.core.now();
+  }
+
+  /**
+   * Generate a DataStore for this run.
+   *
+   * This processes the events to:
+   *  - shift the beginning of the simulation to timestamp 0
+   *  - drop tasks and workers that existed only in the ramp-up
+   *    or ramp-down periods
+   */
+  dataStore() {
+    return DataStore.fromRecorder(this);
+  }
+}
+
+module.exports = {Recorder};

--- a/src/simulator.js
+++ b/src/simulator.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const {Core} = require('./core');
 const {Queue} = require('./queue');
+const {Recorder} = require('./recorder');
 
 class Simulator {
   constructor({logging} = {}) {
@@ -12,6 +13,8 @@ class Simulator {
 
     this.loadGenerator = this.loadGeneratorFactory();
     this.provisioner = this.provisionerFactory();
+
+    this.recorder = new Recorder(this);
   }
 
   run() {
@@ -20,15 +23,24 @@ class Simulator {
     assert.notEqual(this.rampDownTime, undefined);
 
     this.core.log('ramping up');
+    this.loadGenerator.start();
+    this.provisioner.start();
     this.core.run(this.rampUpTime);
 
     this.core.log('running simulation');
+    this.recorder.start();
     this.core.run(this.runTime);
 
     this.core.log('ramping down');
+    this.recorder.stop();
     this.loadGenerator.stop();
     this.core.run(this.rampDownTime);
     this.provisioner.stop();
+    this.queue.stop();
+  }
+
+  dataStore() {
+    return this.recorder.dataStore();
   }
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -27,7 +27,7 @@ class Worker extends Component {
 
   start() {
     this.emit('started');
-    this.queue.on('pending', this.loop);
+    this.queue.on('started', this.loop);
     this.core.nextTick(this.loop);
   }
 
@@ -49,7 +49,7 @@ class Worker extends Component {
       return;
     }
 
-    const task = this.queue.claimWork();
+    const task = this.queue.claimWork(this.name);
     if (task) {
       this.log(`claimed ${task.taskId}`);
       this.runningTask = task;
@@ -94,7 +94,7 @@ class Worker extends Component {
   shutdown() {
     this.log('shutting down');
     this.workerRunning = false;
-    this.queue.removeListener('pending', this.loop);
+    this.queue.removeListener('started', this.loop);
     this.emit('shutdown');
   }
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const crypto = require('crypto');
 const {Component} = require('./component');
 
@@ -9,9 +10,15 @@ const {Component} = require('./component');
  * - 'shutdown' -- when they shut down due to being idle
  */
 class Worker extends Component {
-  constructor({core, queue, startupDelay, idleTimeout}) {
+  constructor({core, queue, startupDelay, idleTimeout, capacity = 1, utility = 1}) {
     super({core, name: `w-${crypto.randomBytes(8).toString('hex')}`});
     this.queue = queue;
+    this.startupDelay = startupDelay;
+    this.idleTimeout = idleTimeout;
+    this.capacity = capacity;
+    this.utility = utility;
+    assert.equal(capacity, 1, 'wait for #3322');
+    assert.equal(utility, 1, 'wait for #3322');
 
     this.workerRunning = true;
 

--- a/test/datastore_test.js
+++ b/test/datastore_test.js
@@ -2,64 +2,64 @@ const assert = require('assert');
 const { DataStore } = require('../src/datastore');
 
 suite('DataStore', function() {
-  test('create from Recorder', function() {
-    const recorder = {
-      startTime: 500,
-      stopTime: 800,
-      events: [
-        // wkr1 / t1 are completed before t=500
-        // wkr2 / t2 are running at simulation start
-        //        t3 is pending at simulation start
-        // wkr3      is starting at simulation start
-        //        t4 is entirely within the simulation
-        // wkr5 / t5 is running when the simulation stops
-        //        t6 is pending when simulation stops
-        // wkr6      is starting when the simulation stops
-        // wkr7 / t7 is entirely after the simulation
-        [0, 'worker-requested', 'wkr1'],
-        [10, 'worker-requested', 'wkr2'],
-        [100, 'task-created', 't1'],
-        [130, 'worker-started', 'wkr1'],
-        [140, 'task-created', 't2'],
-        [150, 'worker-started', 'wkr2'],
-        [190, 'task-started', 't1', 'wkr1'],
-        [200, 'task-started', 't2', 'wkr2'],
-        [400, 'task-resolved', 't1'],
-        [430, 'worker-shutdown', 'wkr1'],
-        [440, 'task-created', 't3'],
-        [460, 'worker-requested', 'wkr3'],
-        // simulation starts
-        [505, 'worker-started', 'wkr3'],
-        [510, 'task-resolved', 't2'],
-        [515, 'worker-started', 'wkr3'],
-        [530, 'task-started', 't3', 'wkr3'],
-        [540, 'task-resolved', 't3'],
-        [550, 'worker-shutdown', 'wkr3'],
-        [560, 'worker-requested', 'wkr5'],
-        [570, 'worker-started', 'wkr5'],
-        [580, 'worker-requested', 'wkr6'],
-        [590, 'task-created', 't4'],
-        [600, 'task-started', 't4', 'wkr5'],
-        [610, 'task-resolved', 't4'],
-        [620, 'task-created', 't5'],
-        [630, 'task-started', 't5', 'wkr5'],
-        [640, 'task-created', 't6'],
-        // simulation ends
-        [810, 'worker-shutdown', 'wkr5'],
-        [820, 'task-resolved', 't5'],
-        [840, 'task-resolved', 't6'],
-        [850, 'worker-started', 'wkr6'],
-        [830, 'task-started', 't6', 'wkr5'],
-        [860, 'worker-requested', 'wkr7'],
-        [870, 'task-created', 't7'],
-        [880, 'task-started', 't7', 'wkr7'],
-        [890, 'worker-shutdown', 'wkr6'],
-        [900, 'worker-started', 'wkr7'],
-        [910, 'worker-shutdown', 'wkr7'],
-        [920, 'task-resolved', 't7'],
-      ],
-    };
+  // a fake recorder with the properties required by fromRecorder
+  const recorder = {
+    startTime: 500,
+    stopTime: 800,
+    events: [
+      // wkr1 / t1 are completed before t=500
+      // wkr2 / t2 are running at simulation start
+      //        t3 is pending at simulation start
+      // wkr3      is starting at simulation start
+      //        t4 is entirely within the simulation
+      // wkr5 / t5 is running when the simulation stops
+      //        t6 is pending when simulation stops
+      // wkr6      is starting when the simulation stops
+      // wkr7 / t7 is entirely after the simulation
+      [0, 'worker-requested', 'wkr1'],
+      [10, 'worker-requested', 'wkr2'],
+      [100, 'task-created', 't1'],
+      [130, 'worker-started', 'wkr1'],
+      [140, 'task-created', 't2'],
+      [150, 'worker-started', 'wkr2'],
+      [190, 'task-started', 't1', 'wkr1'],
+      [200, 'task-started', 't2', 'wkr2'],
+      [400, 'task-resolved', 't1'],
+      [430, 'worker-shutdown', 'wkr1'],
+      [440, 'task-created', 't3'],
+      [460, 'worker-requested', 'wkr3'],
+      // simulation starts
+      [505, 'worker-started', 'wkr3'],
+      [510, 'task-resolved', 't2'],
+      [530, 'task-started', 't3', 'wkr3'],
+      [540, 'task-resolved', 't3'],
+      [550, 'worker-shutdown', 'wkr3'],
+      [560, 'worker-requested', 'wkr5'],
+      [570, 'worker-started', 'wkr5'],
+      [580, 'worker-requested', 'wkr6'],
+      [590, 'task-created', 't4'],
+      [600, 'task-started', 't4', 'wkr5'],
+      [610, 'task-resolved', 't4'],
+      [620, 'task-created', 't5'],
+      [630, 'task-started', 't5', 'wkr5'],
+      [640, 'task-created', 't6'],
+      // simulation ends
+      [810, 'worker-shutdown', 'wkr5'],
+      [820, 'task-resolved', 't5'],
+      [840, 'task-resolved', 't6'],
+      [850, 'worker-started', 'wkr6'],
+      [830, 'task-started', 't6', 'wkr5'],
+      [860, 'worker-requested', 'wkr7'],
+      [870, 'task-created', 't7'],
+      [880, 'task-started', 't7', 'wkr7'],
+      [890, 'worker-shutdown', 'wkr6'],
+      [900, 'worker-started', 'wkr7'],
+      [910, 'worker-shutdown', 'wkr7'],
+      [920, 'task-resolved', 't7'],
+    ],
+  };
 
+  test('create from Recorder', function() {
     const ds = DataStore.fromRecorder(recorder);
     assert.equal(ds.duration, 300);
     assert.deepEqual(ds.events, [
@@ -72,7 +72,6 @@ suite('DataStore', function() {
       // simulation starts
       [5, 'worker-started', 'wkr3'],
       [10, 'task-resolved', 't2'],
-      [15, 'worker-started', 'wkr3'],
       [30, 'task-started', 't3', 'wkr3'],
       [40, 'task-resolved', 't3'],
       [50, 'worker-shutdown', 'wkr3'],
@@ -109,5 +108,169 @@ suite('DataStore', function() {
     const ds2 = DataStore.fromSerializable(ser);
     assert.equal(ds.duration, ds2.duration);
     assert.deepEqual(ds.events, ds2.events);
+  });
+
+  suite('calculateMetrics', function() {
+    let ds;
+    suiteSetup(function() {
+      ds = DataStore.fromRecorder(recorder);
+    });
+
+    test('custom metric at 100ms', function() {
+      const metrics = ds.calculateMetrics({
+        interval: 100,
+        metrics: {custom: state => state.pendingTasks.size + state.runningTasks.size + state.resolvedTasks.size},
+      });
+      assert.deepEqual(metrics, [
+        {time: 0, custom: 2},
+        {time: 100, custom: 3},
+        {time: 200, custom: 5},
+        {time: 300, custom: 5},
+      ]);
+    });
+
+    test('pendingTasks at 100ms', function() {
+      const metrics = ds.calculateMetrics({interval: 100, metrics: {pendingTasks: DataStore.pendingTasks}});
+      assert.deepEqual(metrics, [
+        {time: 0, pendingTasks: 1},
+        {time: 100, pendingTasks: 0},
+        {time: 200, pendingTasks: 1},
+        {time: 300, pendingTasks: 1},
+      ]);
+    });
+
+    test('pendingTasks at 50ms', function() {
+      const metrics = ds.calculateMetrics({interval: 50, metrics: {pendingTasks: DataStore.pendingTasks}});
+      assert.deepEqual(metrics, [
+        {time: 0, pendingTasks: 1},
+        {time: 50, pendingTasks: 0},
+        {time: 100, pendingTasks: 0},
+        {time: 150, pendingTasks: 1},
+        {time: 200, pendingTasks: 1},
+        {time: 250, pendingTasks: 1},
+        {time: 300, pendingTasks: 1},
+      ]);
+    });
+
+    test('resolvedTasks at 100ms', function() {
+      const metrics = ds.calculateMetrics({interval: 100, metrics: {resolvedTasks: DataStore.resolvedTasks}});
+      assert.deepEqual(metrics, [
+        { time: 0, resolvedTasks: 0 },
+        { time: 100, resolvedTasks: 2 },
+        { time: 200, resolvedTasks: 3 },
+        { time: 300, resolvedTasks: 3 },
+      ]);
+    });
+
+    test('runningTasks at 100ms', function() {
+      const metrics = ds.calculateMetrics({interval: 100, metrics: {runningTasks: DataStore.runningTasks}});
+      assert.deepEqual(metrics, [
+        {time: 0, runningTasks: 1},
+        {time: 100, runningTasks: 1},
+        {time: 200, runningTasks: 1},
+        {time: 300, runningTasks: 1},
+      ]);
+    });
+
+    test('requestedWorkers at 25ms', function() {
+      const metrics = ds.calculateMetrics({interval: 25, metrics: {requestedWorkers: DataStore.requestedWorkers}});
+      assert.deepEqual(metrics, [
+        { time: 0, requestedWorkers: 1 },
+        { time: 25, requestedWorkers: 0 },
+        { time: 50, requestedWorkers: 0 },
+        { time: 75, requestedWorkers: 0 },
+        { time: 100, requestedWorkers: 1 }, // wkr6 takes forever to start..
+        { time: 125, requestedWorkers: 1 },
+        { time: 150, requestedWorkers: 1 },
+        { time: 175, requestedWorkers: 1 },
+        { time: 200, requestedWorkers: 1 },
+        { time: 225, requestedWorkers: 1 },
+        { time: 250, requestedWorkers: 1 },
+        { time: 275, requestedWorkers: 1 },
+        { time: 300, requestedWorkers: 1 },
+      ]);
+    });
+
+    test('runningWorkers at 100ms', function() {
+      const metrics = ds.calculateMetrics({interval: 100, metrics: {runningWorkers: DataStore.runningWorkers}});
+      assert.deepEqual(metrics, [
+        { time: 0, runningWorkers: 1 },
+        { time: 100, runningWorkers: 2 },
+        { time: 200, runningWorkers: 2 },
+        { time: 300, runningWorkers: 2 },
+      ]);
+    });
+
+    test('shutdownWorkers at 100ms', function() {
+      const metrics = ds.calculateMetrics({interval: 100, metrics: {shutdownWorkers: DataStore.shutdownWorkers}});
+      assert.deepEqual(metrics, [
+        { time: 0, shutdownWorkers: 0 },
+        { time: 100, shutdownWorkers: 1 },
+        { time: 200, shutdownWorkers: 1 },
+        { time: 300, shutdownWorkers: 1 },
+      ]);
+    });
+
+    test('custom state function at 10ms', function() {
+      const metrics = ds.calculateMetrics({
+        interval: 10,
+        metrics: {
+          overProvisionedWorkers(state) {
+            return state.overProvisionedWorkers.size;
+          },
+        },
+        initialState: {overProvisionedWorkers: new Map()},
+        updateState: (state, [time, name, ...rest]) => {
+          switch (name) {
+            case 'worker-started': {
+              const [workerId] = rest;
+              const worker = state.runningWorkers.get(workerId);
+              state.overProvisionedWorkers.set(workerId, worker);
+              break;
+            }
+
+            case 'task-started': {
+              const [_, workerId] = rest;
+              state.overProvisionedWorkers.delete(workerId);
+              break;
+            }
+          }
+        },
+      });
+
+      assert.deepEqual(metrics, [
+        { time: 0, overProvisionedWorkers: 0 },
+        { time: 10, overProvisionedWorkers: 1 },
+        { time: 20, overProvisionedWorkers: 1 },
+        { time: 30, overProvisionedWorkers: 0 },
+        { time: 40, overProvisionedWorkers: 0 },
+        { time: 50, overProvisionedWorkers: 0 },
+        { time: 60, overProvisionedWorkers: 0 },
+        { time: 70, overProvisionedWorkers: 1 },
+        { time: 80, overProvisionedWorkers: 1 },
+        { time: 90, overProvisionedWorkers: 1 },
+        { time: 100, overProvisionedWorkers: 0 },
+        { time: 110, overProvisionedWorkers: 0 },
+        { time: 120, overProvisionedWorkers: 0 },
+        { time: 130, overProvisionedWorkers: 0 },
+        { time: 140, overProvisionedWorkers: 0 },
+        { time: 150, overProvisionedWorkers: 0 },
+        { time: 160, overProvisionedWorkers: 0 },
+        { time: 170, overProvisionedWorkers: 0 },
+        { time: 180, overProvisionedWorkers: 0 },
+        { time: 190, overProvisionedWorkers: 0 },
+        { time: 200, overProvisionedWorkers: 0 },
+        { time: 210, overProvisionedWorkers: 0 },
+        { time: 220, overProvisionedWorkers: 0 },
+        { time: 230, overProvisionedWorkers: 0 },
+        { time: 240, overProvisionedWorkers: 0 },
+        { time: 250, overProvisionedWorkers: 0 },
+        { time: 260, overProvisionedWorkers: 0 },
+        { time: 270, overProvisionedWorkers: 0 },
+        { time: 280, overProvisionedWorkers: 0 },
+        { time: 290, overProvisionedWorkers: 0 },
+        { time: 300, overProvisionedWorkers: 0 },
+      ]);
+    });
   });
 });

--- a/test/datastore_test.js
+++ b/test/datastore_test.js
@@ -1,0 +1,113 @@
+const assert = require('assert');
+const { DataStore } = require('../src/datastore');
+
+suite('DataStore', function() {
+  test('create from Recorder', function() {
+    const recorder = {
+      startTime: 500,
+      stopTime: 800,
+      events: [
+        // wkr1 / t1 are completed before t=500
+        // wkr2 / t2 are running at simulation start
+        //        t3 is pending at simulation start
+        // wkr3      is starting at simulation start
+        //        t4 is entirely within the simulation
+        // wkr5 / t5 is running when the simulation stops
+        //        t6 is pending when simulation stops
+        // wkr6      is starting when the simulation stops
+        // wkr7 / t7 is entirely after the simulation
+        [0, 'worker-requested', 'wkr1'],
+        [10, 'worker-requested', 'wkr2'],
+        [100, 'task-created', 't1'],
+        [130, 'worker-started', 'wkr1'],
+        [140, 'task-created', 't2'],
+        [150, 'worker-started', 'wkr2'],
+        [190, 'task-started', 't1', 'wkr1'],
+        [200, 'task-started', 't2', 'wkr2'],
+        [400, 'task-resolved', 't1'],
+        [430, 'worker-shutdown', 'wkr1'],
+        [440, 'task-created', 't3'],
+        [460, 'worker-requested', 'wkr3'],
+        // simulation starts
+        [505, 'worker-started', 'wkr3'],
+        [510, 'task-resolved', 't2'],
+        [515, 'worker-started', 'wkr3'],
+        [530, 'task-started', 't3', 'wkr3'],
+        [540, 'task-resolved', 't3'],
+        [550, 'worker-shutdown', 'wkr3'],
+        [560, 'worker-requested', 'wkr5'],
+        [570, 'worker-started', 'wkr5'],
+        [580, 'worker-requested', 'wkr6'],
+        [590, 'task-created', 't4'],
+        [600, 'task-started', 't4', 'wkr5'],
+        [610, 'task-resolved', 't4'],
+        [620, 'task-created', 't5'],
+        [630, 'task-started', 't5', 'wkr5'],
+        [640, 'task-created', 't6'],
+        // simulation ends
+        [810, 'worker-shutdown', 'wkr5'],
+        [820, 'task-resolved', 't5'],
+        [840, 'task-resolved', 't6'],
+        [850, 'worker-started', 'wkr6'],
+        [830, 'task-started', 't6', 'wkr5'],
+        [860, 'worker-requested', 'wkr7'],
+        [870, 'task-created', 't7'],
+        [880, 'task-started', 't7', 'wkr7'],
+        [890, 'worker-shutdown', 'wkr6'],
+        [900, 'worker-started', 'wkr7'],
+        [910, 'worker-shutdown', 'wkr7'],
+        [920, 'task-resolved', 't7'],
+      ],
+    };
+
+    const ds = DataStore.fromRecorder(recorder);
+    assert.equal(ds.duration, 300);
+    assert.deepEqual(ds.events, [
+      [-490, 'worker-requested', 'wkr2'],
+      [-360, 'task-created', 't2'],
+      [-350, 'worker-started', 'wkr2'],
+      [-300, 'task-started', 't2', 'wkr2'],
+      [-60, 'task-created', 't3'],
+      [-40, 'worker-requested', 'wkr3'],
+      // simulation starts
+      [5, 'worker-started', 'wkr3'],
+      [10, 'task-resolved', 't2'],
+      [15, 'worker-started', 'wkr3'],
+      [30, 'task-started', 't3', 'wkr3'],
+      [40, 'task-resolved', 't3'],
+      [50, 'worker-shutdown', 'wkr3'],
+      [60, 'worker-requested', 'wkr5'],
+      [70, 'worker-started', 'wkr5'],
+      [80, 'worker-requested', 'wkr6'],
+      [90, 'task-created', 't4'],
+      [100, 'task-started', 't4', 'wkr5'],
+      [110, 'task-resolved', 't4'],
+      [120, 'task-created', 't5'],
+      [130, 'task-started', 't5', 'wkr5'],
+      [140, 'task-created', 't6'],
+      // simulation ends
+      [310, 'worker-shutdown', 'wkr5'],
+      [320, 'task-resolved', 't5'],
+      [340, 'task-resolved', 't6'],
+      [350, 'worker-started', 'wkr6'],
+      [330, 'task-started', 't6', 'wkr5'],
+      [390, 'worker-shutdown', 'wkr6'],
+    ]);
+  });
+
+  test('asSerializable / fromSerializable', function() {
+    const ds = new DataStore();
+    ds.duration = 10;
+    ds.events = [[0, 'worker-started', 'wkr1']];
+
+    const ser = ds.asSerializable();
+    assert.deepEqual(ser, {
+      duration: 10,
+      events: [[0, 'worker-started', 'wkr1']],
+    });
+
+    const ds2 = DataStore.fromSerializable(ser);
+    assert.equal(ds.duration, ds2.duration);
+    assert.deepEqual(ds.events, ds2.events);
+  });
+});

--- a/test/recorder_test.js
+++ b/test/recorder_test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { Core } = require('../src/core');
+const { Recorder } = require('../src/recorder');
+
+suite('Recorder', function() {
+  let core, queue, provisioner, recorder;
+
+  setup('create core', function() {
+    core = new Core({logging: false});
+    queue = new EventEmitter();
+    provisioner = new EventEmitter();
+    const simulator = { core, queue, provisioner };
+    recorder = new Recorder(simulator);
+  });
+
+  test('gathers events', function() {
+    const at = (t, fn) => core.setTimeout(fn, t);
+    at(0, () => provisioner.emit('requested', 'wkr1'));
+    at(100, () => queue.emit('created', 't1'));
+    at(150, () => provisioner.emit('started', 'wkr1'));
+    at(200, () => queue.emit('started', 't1', 'wkr1'));
+    at(300, () => recorder.start());
+    at(400, () => queue.emit('resolved', 't1'));
+    at(500, () => recorder.stop());
+    at(600, () => provisioner.emit('shutdown', 'wkr1'));
+    core.run(1000);
+
+    assert.equal(recorder.startTime, 300);
+    assert.equal(recorder.stopTime, 500);
+    assert.deepEqual(recorder.events, [
+      [0, 'worker-requested', 'wkr1'],
+      [100, 'task-created', 't1'],
+      [150, 'worker-started', 'wkr1'],
+      [200, 'task-started', 't1', 'wkr1'],
+      [400, 'task-resolved', 't1'],
+      [600, 'worker-shutdown', 'wkr1'],
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,6 +847,11 @@ mocha@^8.1.0:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.1"
 
+mock-fs@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.12.0.tgz#a5d50b12d2d75e5bec9dac3b67ffe3c41d31ade4"
+  integrity sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==
+
 ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"


### PR DESCRIPTION
This should cover a few tiers of complexity of analysis, from a basic "what's running" to more sophisticated things like those suggested in the README.  My thinking is that we can implement those in an ad-hoc way in the simulators or the visualization framework, and as we find particularly useful metrics we can move them into the library.

Fixes taskcluster/taskcluster#3320.