### PR TITLE
Implement each simulator as a subcommand of yarn sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,11 @@ To run a simulation, use
 yarn sim $SIMULATION
 ```
 
-the available simulations are defined in `.js` files in `sims`.
+the simulations are defined in `.js` files in `sims`.
+Run `yarn sim --help` to see them.
 
 Add `-q` to quiet down the logging.
-Add `-o <output>` to output the simulation data to `<output>`.
+Add `-o <output>` to output the simulation datastore to `<output>` (defaulting to `datastore.json`).
 
 ## UI
 

--- a/main.js
+++ b/main.js
@@ -1,25 +1,43 @@
+const commander = require('commander');
 const chalk = require('chalk');
-const {program} = require('commander');
-const {version} = require('./package.json');
 const fs = require('fs');
+const {version} = require('./package.json');
 
-program.version(version);
+const sim = new commander.Command('sim')
+  .description('run a simulation')
+  .option('-o, --output <datastore>', 'write the datastore to <datastore> (default `datastore.json`)')
+  .option('-q, --quiet', 'silence logging');
 
-program
-  .option('-q, --quiet', 'silence logging')
-  .option('-o, --output <output>', 'datastore ouptut')
-  .arguments('<simulation>')
-  .action((simName, options) => {
-    const Simulator = require(`./sims/${simName}`);
-    const sim = new Simulator({
-      logging: !options.quiet,
+fs.readdirSync(`${__dirname}/sims`).forEach(file => {
+  const m = file.match(/^(.*)\.js/);
+  if (m) {
+    const [_, name] = m;
+    const {Simulator, setup} = require(`./sims/${name}`);
+    const subcommand = new commander.Command(name);
+    setup(subcommand);
+    subcommand.action((...args) => {
+      const simOptions = sim.opts();
+
+      const simulator = new Simulator({
+        logging: !simOptions.quiet,
+        commandArgs: args.slice(0, args.length - 2),
+        commandOptions: subcommand.opts(),
+      });
+
+      console.log(chalk`{red ➤} {bold Running Simulation}`);
+      simulator.run();
+
+      const filename = simOptions.output || 'datastore.json';
+      console.log(chalk`{red ➤} {bold Writing result to ${filename}}`);
+      const ds = simulator.dataStore();
+      fs.writeFileSync(filename, JSON.stringify(ds.asSerializable()));
     });
+    sim.addCommand(subcommand);
+  }
+});
 
-    sim.run();
-    if (options.output) {
-      const ds = sim.dataStore();
-      fs.writeFileSync(options.output, JSON.stringify(ds.asSerializable()));
-    }
-  });
+const program = new commander.Command()
+  .version(version)
+  .addCommand(sim);
 
 program.parse();

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ fs.readdirSync(`${__dirname}/sims`).forEach(file => {
 
       const simulator = new Simulator({
         logging: !simOptions.quiet,
-        commandArgs: args.slice(0, args.length - 2),
+        commandArgs: args.slice(0, args.length - 1),
         commandOptions: subcommand.opts(),
       });
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "webpack-dev-server --mode development --open",
     "build": "webpack --mode production",
     "lint": "eslint src/*.js test/*.js",
-    "sim": "node main.js",
+    "sim": "node main.js sim",
     "test": "mocha test/*_test.js"
   },
   "author": "",

--- a/sims/simple.js
+++ b/sims/simple.js
@@ -4,11 +4,11 @@ const {TickTockLoadGenerator} = require('./loadgen/ticktock');
 const {SimpleEstimateProvisioner} = require('./prov/simple');
 
 class SimpleSimulator extends Simulator {
-  constructor(options) {
+  constructor({commandOptions, ...options}) {
     super(options);
 
     this.rampUpTime = 10000;
-    this.runTime = 10000;
+    this.runTime = commandOptions.duration ? parseInt(commandOptions.duration, 10) : 10000;
     this.rampDownTime = 20000;
   }
 
@@ -35,6 +35,16 @@ class SimpleSimulator extends Simulator {
       }),
     });
   }
-};
+}
 
-module.exports = SimpleSimulator;
+module.exports = {
+  setup(command) {
+    command
+      .description('simple simulation with tasks injected regularly and a "simple estimate" provisioner')
+      .option(
+        '-d, --duration <ms>',
+        'duration (in ms) to run the simulation (excluding ramp up/down)',
+      );
+  },
+  Simulator: SimpleSimulator,
+};


### PR DESCRIPTION
This gets nicer --help output and also means each simulator can take its
own parameters on the command line.

This was part of my work on #3360 but now that we have a React viewer I think that's going to take a totally different tack.