### PR TITLE
Introduce a manual provisioner

### DIFF
--- a/sims/manual.js
+++ b/sims/manual.js
@@ -1,0 +1,65 @@
+const {Simulator} = require('..');
+const {Worker} = require('..');
+const {TickTockLoadGenerator} = require('./loadgen/ticktock');
+const {ManualProvisioner} = require('./prov/manual');
+
+class SimpleSimulator extends Simulator {
+  constructor({commandOptions, ...options}) {
+    super(options);
+
+    const hour = 1000 * 3600;
+    this.rampUpTime = hour;
+    this.runTime = 24 * hour;
+    this.rampDownTime = hour;
+
+    this.workers = commandOptions.workers;
+    this.workload = commandOptions.workload;
+  }
+
+  loadGeneratorFactory() {
+    // at a workload of 1, we inject 1 minute of work every minute; with higher workloads,
+    // inject tasks more frequently, with longer durations.
+    const sqrtWorkload = Math.sqrt(this.workload);
+    const taskDuration = (60 * 1000) * sqrtWorkload;
+    const taskEvery = (60 * 1000) / sqrtWorkload;
+
+    return new TickTockLoadGenerator({
+      core: this.core,
+      queue: this.queue,
+      taskEvery,
+      taskDuration,
+    });
+  }
+
+  provisionerFactory() {
+    return new ManualProvisioner({
+      core: this.core,
+      queue: this.queue,
+      capacityFn: now => this.workers,
+      workerFactory: () => new Worker({
+        core: this.core,
+        queue: this.queue,
+        startupDelay: 10000,
+        idleTimeout: 60000,
+      }),
+    });
+  }
+}
+
+module.exports = {
+  setup(command) {
+    command
+      .description('simple simulation with a regular injection of work and a manual provisioner')
+      .requiredOption(
+        '--workers <count>',
+        'number of workers to run',
+        parseInt,
+      )
+      .requiredOption(
+        '--workload <factor>',
+        'seconds per second of work to inject',
+        Number,
+      );
+  },
+  Simulator: SimpleSimulator,
+};

--- a/sims/manual.js
+++ b/sims/manual.js
@@ -57,7 +57,7 @@ module.exports = {
       )
       .requiredOption(
         '--workload <factor>',
-        'seconds per second of work to inject',
+        'quantity of work (task execution) to create as a ratio of total task duration to time',
         Number,
       );
   },

--- a/sims/prov/manual.js
+++ b/sims/prov/manual.js
@@ -1,0 +1,55 @@
+const {Provisioner} = require('../..');
+
+/**
+ * ManualProvider duplicates the behavior of the current (as of 36.0.0) worker-manager
+ * provisioning algorithm.
+ *
+ * Constructor args:
+ * - core
+ * - queue
+ * - capacityFn -- a callable given the current time that returns the number of workers that should exist.
+ * - workerFactory -- a callable that will create a new worker
+ */
+class ManualProvisioner extends Provisioner {
+  constructor({core, queue, capacityFn, workerFactory}) {
+    super({core});
+    this.queue = queue;
+    this.capacityFn = capacityFn;
+    this.workerFactory = workerFactory;
+
+    this.requestedWorkers = new Map();
+    this.runningWorkers = new Map();
+  }
+
+  start() {
+    this.core.setInterval(() => this.loop(), 10000);
+  }
+
+  stop() {
+    // don't check for extra, idle workers, as we expect to find them!
+  }
+
+  loop() {
+    const desiredCapacity = this.capacityFn(this.core.now());
+    const totalCurrentCapacity = this.runningWorkers.size + this.requestedWorkers.size;
+
+    let toSpawn = Math.max(0, desiredCapacity - totalCurrentCapacity);
+
+    while (toSpawn > 0) {
+      toSpawn--;
+
+      const worker = this.workerFactory();
+      this.registerWorker(worker);
+      this.requestedWorkers.set(worker.name, worker);
+      worker.once('started', () => {
+        this.requestedWorkers.delete(worker.name);
+        this.runningWorkers.set(worker.name, worker);
+      });
+      worker.once('shutdown', () => {
+        this.runningWorkers.delete(worker.name);
+      });
+    }
+  }
+}
+
+exports.ManualProvisioner = ManualProvisioner;

--- a/src/provisioner.js
+++ b/src/provisioner.js
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const {Component} = require('./component');
 
 /**
@@ -33,8 +32,10 @@ class Provisioner extends Component {
 
   stop() {
     // check that all workers have stopped
-    const runningWorkers = [...this.workers.keys()];
-    assert.deepEqual(runningWorkers, []);
+    const runningWorkers = this.workers.size;
+    if (runningWorkers !== 0) {
+      this.log(`NOTE: ${runningWorkers} workers still running at end of ramp-down phase`);
+    }
   }
 }
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const {Component} = require('./component');
 
 /**
@@ -86,10 +87,10 @@ class Queue extends Component {
     const pendingTasks = this._pendingTasks.length;
     const runningTasks = this._runningTasks.size;
     if (pendingTasks !== 0) {
-      this.log(`NOTE: ${pendingTasks} tasks still pending at end of ramp-down phase`);
+      this.log(chalk`{red WARNING:} ${pendingTasks} tasks still pending at end of ramp-down phase`);
     }
     if (runningTasks !== 0) {
-      this.log(`NOTE: ${runningTasks} tasks running at end of ramp-down phase`);
+      this.log(chalk`{red WARNING:} ${runningTasks} tasks running at end of ramp-down phase`);
     }
   }
 }

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,5 +1,4 @@
 const {Component} = require('./component');
-const assert = require('assert');
 
 /**
  * Simulator for the TC Queue.
@@ -84,8 +83,14 @@ class Queue extends Component {
    * Stop the queue, checking that all tasks are resolved
    */
   stop() {
-    assert.deepEqual([...this._pendingTasks.keys()], []);
-    assert.deepEqual([...this._runningTasks.keys()], []);
+    const pendingTasks = this._pendingTasks.length;
+    const runningTasks = this._runningTasks.size;
+    if (pendingTasks !== 0) {
+      this.log(`NOTE: ${pendingTasks} tasks still pending at end of ramp-down phase`);
+    }
+    if (runningTasks !== 0) {
+      this.log(`NOTE: ${runningTasks} tasks running at end of ramp-down phase`);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes taskcluster/taskcluster#3375.

This supports a time-of-day manual scheduling, in that the `capacityFn` takes `now` as an argument, but I haven't used this in any of the defined simulators.